### PR TITLE
Add onChange support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 npm-debug.log
+bundle.js

--- a/demo/index.js
+++ b/demo/index.js
@@ -7,8 +7,8 @@ const NUM_ITEMS = 360;
 const root = document.querySelector('#root');
 
 class Colors extends Component {
-    constructor() {
-        super(...arguments);
+    constructor(props) {
+        super(props);
         const colors = new Array(NUM_ITEMS).fill('').map((i, idx) => {
             return {
                 bg: `hsl(${(idx / NUM_ITEMS) * 360},100%,50%)`
@@ -17,13 +17,15 @@ class Colors extends Component {
         this.state = {
             colors
         };
+
     }
     renderItem(item, idx) {
         return (
             <OnVisible
                 className="box"
                 percent={10}
-                key={idx}>
+                key={idx}
+                onChange={(state) => { console.log(state); }}>
                 <div data-idx={`box: ${idx}`} style={{
                     backgroundColor: item.bg,
                     transitionDelay: `${idx % 3 * 100}ms`

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ import cx from 'classnames';
 import debounce from './lib/debounce';
 
 class OnVisible extends Component {
-    constructor() {
-        super(...arguments);
+    constructor(props) {
+        super(props);
         this.onScroll = debounce(this.onScroll.bind(this), 10);
         this.state = {
             visible: false,
@@ -36,6 +36,8 @@ class OnVisible extends Component {
             this.setState({
                 visible: true,
                 top
+            }, function() {
+                if (this.props.onChange) this.props.onChange(this.state.visible);
             });
             this.stopListening();
         }
@@ -67,7 +69,8 @@ OnVisible.propTypes = {
     style: PropTypes.object,
     visibleClassName: PropTypes.string,
     children: PropTypes.node,
-    percent: PropTypes.number
+    percent: PropTypes.number,
+    onChange: PropTypes.func,
 };
 
 export default OnVisible;


### PR DESCRIPTION
Pass a function to `onChange`, which will notify you when the component becomes visible. Allows usage of `react-on-visible` in scenarios where using the `.visible` class isn't ideal, e.g., when using CSS modules
