### PR TITLE
Use the prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "homepage": "https://github.com/dazld/react-on-visible#readme",
     "dependencies": {
         "classnames": "^2.2.5",
-        "react": "^15.3.1"
+        "react": "^15.3.1",
+        "prop-types": "^15.5.10"
     },
     "devDependencies": {
         "babel-cli": "^6.14.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* global window, document */
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'; 
 import cx from 'classnames';
 import debounce from './lib/debounce';
 


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated. 
Use the prop-types package from npm instead.
