### PR TITLE
added ability to have an invisible class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* global window, document */
 import React, { Component } from 'react';
-import PropTypes from 'prop-types'; 
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import debounce from './lib/debounce';
 
@@ -56,7 +56,8 @@ class OnVisible extends Component {
     render() {
         const { visible } = this.state;
         const classes = cx(this.props.className, {
-            [this.props.visibleClassName || 'visible']: visible
+            [this.props.visibleClassName || 'visible']: visible,
+            [this.props.invisibleClassName || 'invisible']: !visible
         });
 
         return (
@@ -80,6 +81,7 @@ OnVisible.propTypes = {
     className: PropTypes.string,
     style: PropTypes.object,
     visibleClassName: PropTypes.string,
+    invisibleClassName: PropTypes.string,
     children: PropTypes.node,
     percent: PropTypes.number,
     onChange: PropTypes.func,


### PR DESCRIPTION
If you want to use a class that is the parent of the OnVisible in a transition effect you need to be able to have a class for before it was visible otherwise the animation won't override the before you set on the class.

for example:

```
<section className="fade-in">
	<OnVisible>
		<Article {...props} />
	</OnVisible>
</section>

.fade-in {
  div.visible {
    @include fade-in(3s);
  }
  div {
    opacity: 0;
  }
}
```

if I were to use this I would NOT see the item after as the opacity 0; would still be the dominat style over the fade-in (it's an animation that fades from 0-1 and uses animation-fill-mode: forwards; to change the visibilty to 1 at the end.

however if I have .invisible to me I can do the following:

```
.fade-in {
  div.visible {
    @include fade-in(3s);
  }
  div.invisible {
    opacity: 0;
  }
}
```

which is great because it works for me!