### PR TITLE
don't ever set holder to null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ class OnVisible extends Component {
           <div
               style={this.props.style}
               className={classes}
-              ref={el => { this.holder = el; }}
+              ref={el => { this.holder = el || this.holder; }}
           >
             {this.props.children}
           </div>


### PR DESCRIPTION
For what ever reason, during a page change I was finding that the ref was becoming null for no reason. This PR makes sure that if the holder element was good, then during a transition it goes bad, it won't over-ride with null, it will just cancel the assignment of the new handler.

fixes #11