### PR TITLE
changed debounce out for bindRaf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules
 build
 npm-debug.log
 bundle.js
+
+# ide folders
+.idea
+
+# for now removing package-lock as it's not my decision to include
+package-lock.json

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'; 
 import cx from 'classnames';
-import debounce from './lib/debounce';
+import { bindRaf } from "./lib/bindRaf";
 
 class OnVisible extends Component {
     constructor() {
         super(...arguments);
-        this.onScroll = debounce(this.onScroll.bind(this), 10);
+        this.onScroll = bindRaf(this.onScroll.bind(this));
         this.state = {
             visible: false,
             bottom: 0,

--- a/src/lib/bindRaf.js
+++ b/src/lib/bindRaf.js
@@ -1,15 +1,15 @@
 export const bindRaf = (fn) => {
 	let isRunning = null;
-	let that = null;
+	let self = null;
 	let args = null;
 
 	const run = () => {
 		isRunning = false;
-		fn.apply(that, args);
+		fn.apply(self, args);
 	};
 
 	return () => {
-		that = this;
+		self = this;
 		args = arguments;
 
 		if (isRunning) {

--- a/src/lib/bindRaf.js
+++ b/src/lib/bindRaf.js
@@ -1,0 +1,22 @@
+export const bindRaf = (fn) => {
+	let isRunning = null;
+	let that = null;
+	let args = null;
+
+	const run = () => {
+		isRunning = false;
+		fn.apply(that, args);
+	};
+
+	return () => {
+		that = this;
+		args = arguments;
+
+		if (isRunning) {
+			return;
+		}
+
+		isRunning = true;
+		requestAnimationFrame(run);
+	};
+};

--- a/src/lib/debounce.js
+++ b/src/lib/debounce.js
@@ -1,9 +1,0 @@
-export default function debounce(fn, time) {
-    let timeout;
-    return function() {
-        if (timeout) {
-            timeout = clearTimeout(timeout);
-        }
-        timeout = setTimeout(fn.bind(null, ...arguments), time);
-    };
-}


### PR DESCRIPTION
the debounce that was setup for calling on scroll/resize was 10ms. All browsers that I know of set a FPS cap of 60fps. 1s/60f = 16ms.

So for two reasons I have changed to bindRaf
1. There is no reason to check if we are below the desired point to change the element to visable until we are rendering a new frame, now if the fps tanks to say 25fps the calculations will only call once every 40ms, so 1/4 the calcs when the system is struggling.
2. setTimeout is not guarinteed to call on the time specified. This caused me issues because on my semi-large site, when I scroll, Chrome decides that my timeout callback is less important than the scroll keeping smooth. See https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Reasons_for_delays_longer_than_specified

I came to the conclution that this was required after reading this SOF answer: https://stackoverflow.com/questions/41740082/scroll-events-requestanimationframe-vs-requestidlecallback-vs-passive-event-lis

Also I have not followed your current standards for code, instead of functions I've used ES6 syntax aswell as not using default exports on library functions. If you don't like this feel free to change it around, but this is how I coded it when I was looking for a solution to my problem.

Cheers.